### PR TITLE
Added support for PostgresQL database deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ deployment script.|
 |variable|default|meaning|
 |----------|---------|---------|
 |webserver| **required** | the webserver in front of uWSGI|
+|database| `sqlite3` | the database required by the application. Supported values are `sqlite3` and `postgresql`|
 |site_certificate| **required** | the certificate of the website|
 |site_key|**required**| the key of the certificate|
 
@@ -103,6 +104,15 @@ deployment script.|
 |apache2_check_binary_name | `a2ensite` | same as `nginx_binary_name` but Apache specific|
 |apache2_user| `www-data`| user running the Apache2 daemon|
 |apache2_group| `www-data`| group of the user running the Apache2 daemon|
+
+**PostgresQL**
+
+|variable|default|meaning|
+|----------|---------|---------|
+|postgresql_database | **required** | name of the application-specific database|
+|postgresql_user | **required** | user name used to connect to the database. This user is also the database owner|
+|postgresql_password | **required** | password for the database user|
+
 
 **Additional variables**
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ deployment script.|
 |postgresql_database | **required** | name of the application-specific database|
 |postgresql_user | **required** | user name used to connect to the database. This user is also the database owner|
 |postgresql_password | **required** | password for the database user|
+|postgresql_additonal_users | [] | the list of additional roles to be created in the database|
+|postgresql_dump | | path to the database dump. This will be used to restore the initial state of the database during the very first deployment|
+|postgresql_post_restore | | an optional SQL statement to be executed after restoring the database|
 
 
 **Additional variables**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ uwsgi_additional_options: []
 ## Default webserver: apache2 or nginx
 webserver: nginx
 
+## Default database: sqlite3 or postgresql
+webserver: sqlite3
+
 # Packages to be installed on the host for running this application
 application_additional_packages: []
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,6 @@
 
 - name: restart apache2
   service: name=apache2 state=restarted enabled=yes
+
+- name: restart postgresql
+  service: name=postgresql state=restarted enabled=yes

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -1,0 +1,12 @@
+# PostgresQL configuration
+
+- block:
+  - name: create PostgresQL database and administrative user
+    shell: echo "{{ item }}" | sudo -u postgres psql || true;
+    with_items:
+      - CREATE DATABASE {{ postgresql_database }};
+      - CREATE USER {{ postgresql_user }} WITH ENCRYPTED PASSWORD '{{ postgresql_password }}'
+      - ALTER ROLE {{ postgresql_user }} SET client_encoding TO 'utf8';
+      - ALTER ROLE {{ postgresql_user }} SET default_transaction_isolation TO 'read committed';
+      - ALTER ROLE {{ postgresql_user }} SET timezone to 'UTC';
+      - GRANT ALL PRIVILEGES ON DATABASE {{ postgresql_database }} TO {{ postgresql_user }};

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -63,8 +63,3 @@
       loop: "{{ postgresql_additional_users }}"
       when: postgresql_additional_users is defined
       tags: postgresql, database
-
-    - name: check if initial dump is on disk
-      stat:
-        path: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
-      register: initial_dump_file

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -13,8 +13,8 @@
       copy:
         src: "{{ postgresql_dump }}"
         dest: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
+        owner: "{{ django_deployment_user }}"
         mode: 0400
-        owner: "postgres"
       when: postgresql_dump is defined and postgresql_existence_check is failed
       tags: postgresql, database
 
@@ -68,19 +68,3 @@
       stat:
         path: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
       register: initial_dump_file
-
-    - name: apply database dump (if still on disk)
-      postgresql_db:
-        name: "{{ postgresql_database }}"
-        state: restore
-        target: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
-      become_user: postgres
-      when: initial_dump_file.stat.exists == True
-      register: apply_initial_dump
-      tags: postgresql, database
-
-    - name: remove the dump file if the migration was successfull
-      file:
-        path: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
-        state: absent
-      when: apply_initial_dump is succeeded

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -9,6 +9,15 @@
       tags: postgresql, database
       # will fail if {{ postgresql_database }} is not defined yet
 
+    - name: copy database dump (if available)
+      copy:
+        src: "{{ postgresql_dump }}"
+        dest: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
+        mode: 0400
+        owner: "postgres"
+      when: postgresql_dump is defined and postgresql_existence_check is failed
+      tags: postgresql, database
+
     - name: create PostgresQL database
       postgresql_db:
         name: "{{ postgresql_database }}"
@@ -55,20 +64,23 @@
       when: postgresql_additional_users is defined
       tags: postgresql, database
 
-    - name: copy database dump (if available)
-      copy:
-        src: "{{ postgresql_dump }}"
-        dest: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
-        mode: 0400
-        owner: "postgres"
-      when: postgresql_dump is defined and postgresql_existence_check is failed
-      tags: postgresql, database
+    - name: check if initial dump is on disk
+      stat:
+        path: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
+      register: initial_dump_file
 
-    - name: apply database dump (if available)
+    - name: apply database dump (if still on disk)
       postgresql_db:
         name: "{{ postgresql_database }}"
         state: restore
         target: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
       become_user: postgres
-      when: postgresql_dump is defined and postgresql_existence_check is failed
+      when: initial_dump_file.stat.exists == True
+      register: apply_initial_dump
       tags: postgresql, database
+
+    - name: remove the dump file if the migration was successfull
+      file:
+        path: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
+        state: absent
+      when: apply_initial_dump is succeeded

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -14,7 +14,7 @@
         src: "{{ postgresql_dump }}"
         dest: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
         owner: "{{ django_deployment_user }}"
-        mode: 0400
+        mode: 0600
       when: postgresql_dump is defined and postgresql_existence_check is failed
       tags: postgresql, database
 

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -1,6 +1,14 @@
 # PostgresQL configuration.
 
 - block:
+    - name: check whether the database exists
+      shell: psql -l {{ postgresql_database }}
+      ignore_errors: true
+      register: postgresql_existence_check
+      become_user: postgres
+      tags: postgresql, database
+      # will fail if {{ postgresql_database }} is not defined yet
+
     - name: create PostgresQL database
       postgresql_db:
         name: "{{ postgresql_database }}"
@@ -28,11 +36,39 @@
 
     - name: enable md5 login to the database from localhost
       postgresql_pg_hba:
-        contype: local
         dest: "/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf"
         databases: "{{ postgresql_database }}"
+        users: "{{ postgresql_user }}"
+        contype: local
         method: md5
         state: present
       notify:
         - restart postgresql
+      tags: postgresql, database
+
+    - name: create additional PostgresQL users
+      postgresql_user:
+        name: "{{ item }}"
+        state: present
+      become_user: postgres
+      loop: "{{ postgresql_additional_users }}"
+      when: postgresql_additional_users is defined
+      tags: postgresql, database
+
+    - name: copy database dump (if available)
+      copy:
+        src: "{{ postgresql_dump }}"
+        dest: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
+        mode: 0400
+        owner: "postgres"
+      when: postgresql_dump is defined and postgresql_existence_check is failed
+      tags: postgresql, database
+
+    - name: apply database dump (if available)
+      postgresql_db:
+        name: "{{ postgresql_database }}"
+        state: restore
+        target: "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql"
+      become_user: postgres
+      when: postgresql_dump is defined and postgresql_existence_check is failed
       tags: postgresql, database

--- a/tasks/app_config_postgresql.yml
+++ b/tasks/app_config_postgresql.yml
@@ -1,12 +1,38 @@
-# PostgresQL configuration
+# PostgresQL configuration.
 
 - block:
-  - name: create PostgresQL database and administrative user
-    shell: echo "{{ item }}" | sudo -u postgres psql || true;
-    with_items:
-      - CREATE DATABASE {{ postgresql_database }};
-      - CREATE USER {{ postgresql_user }} WITH ENCRYPTED PASSWORD '{{ postgresql_password }}'
-      - ALTER ROLE {{ postgresql_user }} SET client_encoding TO 'utf8';
-      - ALTER ROLE {{ postgresql_user }} SET default_transaction_isolation TO 'read committed';
-      - ALTER ROLE {{ postgresql_user }} SET timezone to 'UTC';
-      - GRANT ALL PRIVILEGES ON DATABASE {{ postgresql_database }} TO {{ postgresql_user }};
+    - name: create PostgresQL database
+      postgresql_db:
+        name: "{{ postgresql_database }}"
+        encoding: UTF-8
+        state: present
+      become_user: postgres
+      tags: postgresql, database
+
+    - name: create PostgresQL user
+      postgresql_user:
+        name: "{{ postgresql_user }}"
+        password: "{{ postgresql_password }}"
+        encrypted: true
+        state: present
+      become_user: postgres
+      tags: postgresql, database
+
+    - name: set database owner
+      postgresql_owner:
+        obj_name: "{{ postgresql_database }}"
+        obj_type: database
+        new_owner: "{{ postgresql_database }}"
+      become_user: postgres
+      tags: postgresql, database
+
+    - name: enable md5 login to the database from localhost
+      postgresql_pg_hba:
+        contype: local
+        dest: "/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf"
+        databases: "{{ postgresql_database }}"
+        method: md5
+        state: present
+      notify:
+        - restart postgresql
+      tags: postgresql, database

--- a/tasks/check_vars.yml
+++ b/tasks/check_vars.yml
@@ -32,4 +32,8 @@
     - django_dependencies
     - django_environment_variables
     - webserver
+    - database
     - application_additional_packages
+    - postgresql_database
+    - postgresql_user
+    - postgresql_password

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,11 @@
     - django-webservices:app-configuration
   when: webserver=='apache2'
 
+- include: app_config_postgresql.yml
+  tags:
+    - django-webservices:app-configuration
+  when: database=="postgresql"
+
 - include: app_config_deployment_script.yml
   tags:
     - django-webservices:app-configuration

--- a/templates/bamboo_deployment.sh.j2
+++ b/templates/bamboo_deployment.sh.j2
@@ -146,11 +146,15 @@ python manage.py collectstatic --noinput
 echo "*********** fix permissions"
 setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/media
 setfacl -m u:{{ uwsgi_user }}:rx -R $currentD/src/static
-chmod go-rwx $currentD/src/db.sqlite3
-setfacl -m u:{{ uwsgi_user }}:rwx $currentD/src/db.sqlite3
+
 setfacl -m u:{{ uwsgi_user }}:rwx $currentD/src
 setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/logs
 setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/temporary
+
+{% if database=="sqlite3" %}
+chmod go-rwx $currentD/src/db.sqlite3
+setfacl -m u:{{ uwsgi_user }}:rwx $currentD/src/db.sqlite3
+{% endif %}
 
 # compile all
 python -m compileall $currentD/src/

--- a/templates/bamboo_deployment.sh.j2
+++ b/templates/bamboo_deployment.sh.j2
@@ -128,7 +128,10 @@ if [ -f "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.s
     cat {{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql | sudo -u postgres psql {{ postgresql_database }}
 
     # remove the dump so we don't try to apply it the second time
-    $? && rm {{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql;
+    if [ $? -eq 0 ]; then
+        echo "*********** dump was succesfully applied. Removing the dump file.";
+        rm {{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql;
+    fi
 
     {% if postgresql_post_restore is defined %}
     # It's possible we still need to alter the database

--- a/templates/bamboo_deployment.sh.j2
+++ b/templates/bamboo_deployment.sh.j2
@@ -103,9 +103,40 @@ fi
 export DJANGO_SETTINGS_MODULE={{ django_settings_file }}
 export DJANGO_SETTINGS_SECRET_FILE={{ django_deployment_root_folder }}/{{ url }}/secrets.py
 
-# applies the migrations and deflate the statics
 echo "*********** migrating the database"
 cd $currentD/src
+{% if postgresql_dump is defined %}
+
+if [ -f "{{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql" ] ; then
+    # If there is an existing database dump we have to proceed
+    # carefully. The dump might already contain all the necessary
+    # django models not only for the app itself, but also the standard
+    # django models including content types, auth, admin and so on.
+
+    # The strategy that worked so far for the only application we have is to:
+    # 1. Apply all the standard django migrations.
+    # 2. Apply the initial migration.
+    # 3. Apply the database dump.
+    # 4. Proceed with the rest of migrations.
+
+    python manage.py migrate contenttypes
+    python3 manage.py migrate auth
+    python3 manage.py migrate admin
+    python3 manage.py migrate sessions
+    python3 manage.py migrate {{ django_source_folder }} 0001_initial --fake-initial
+
+    cat {{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql | sudo -u postgres psql {{ postgresql_database }}
+
+    # remove the dump so we don't try to apply it the second time
+    $? && rm {{ django_deployment_root_folder }}/{{ url }}/postgresql_initial_dump.sql;
+
+    {% if postgresql_post_restore is defined %}
+    # It's possible we still need to alter the database
+    sudo -u postgres psql {{ postgresql_database }} -c "{{ postgresql_post_restore }}"
+    {% endif %}
+fi
+
+{% endif %}
 python manage.py migrate --noinput -v3
 
 echo "*********** collecting the statics"

--- a/templates/bamboo_deployment.sh.j2
+++ b/templates/bamboo_deployment.sh.j2
@@ -147,12 +147,11 @@ python manage.py collectstatic --noinput
 
 # mutates the file permissions for the uwsgi user
 echo "*********** fix permissions"
-setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/media
-setfacl -m u:{{ uwsgi_user }}:rx -R $currentD/src/static
-
 setfacl -m u:{{ uwsgi_user }}:rwx $currentD/src
-setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/logs
-setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/temporary
+[ -d "$currentD/src/logs" ]      && setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/logs
+[ -d "$currentD/src/temporary" ] && setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/temporary
+[ -d "$currentD/src/media" ]     && setfacl -m u:{{ uwsgi_user }}:rwx -R $currentD/src/media
+[ -d "$currentD/src/static" ]    && setfacl -m u:{{ uwsgi_user }}:rx  -R $currentD/src/static
 
 {% if database=="sqlite3" %}
 chmod go-rwx $currentD/src/db.sqlite3


### PR DESCRIPTION
In addition to sqlite3 this role now supports PostgresQL database. In case of PostgresQL it is also now possible to supply a dump of the initial database state to be restored during the very first deployment but before the all the nontrivial migrations are made. 

PS: As of time of writing nginx responds with 502 Bad Gateway after the deployment, but this surely will be fixed soon.